### PR TITLE
implement memory.fill and memory.copy

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -560,6 +560,8 @@ generate! { instr -> Instr = {
                 0x05 => Instr::ICvtOp(BitSize::B64, intop::CvtOp::TruncSatUF32),
                 0x06 => Instr::ICvtOp(BitSize::B64, intop::CvtOp::TruncSatSF64),
                 0x07 => Instr::ICvtOp(BitSize::B64, intop::CvtOp::TruncSatUF64),
+                0x0a => { run!(expect_byte(0x00)); run!(expect_byte(0x00)); Instr::MemCopy },
+                0x0b => { run!(expect_byte(0x00)); Instr::MemFill },
                 b => err!("Invalid saturation trunctation {:#x}", b),
             }
         }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -639,6 +639,24 @@ fn print_instr(
                 }
             }
         }
+        MemFill => {
+            let n = pop!(i32);
+            let v = pop!(i32);
+            let addr = pop!(i32);
+            let addr_end = format!("({} + {})", addr, n);
+
+            Ok(format!("self.memory[{} as usize..{} as usize].fill({} as u8);",
+                addr, addr_end, v))
+        }
+        MemCopy => {
+            let n = pop!(i32);
+            let src = pop!(i32);
+            let dst = pop!(i32);
+            let src_end = format!("({} + {})", src, n);
+
+            Ok(format!("self.memory.copy_within({} as usize..{} as usize, {} as usize);",
+                src, src_end, dst))
+        }
         MemSize => {
             // Note: The spec defines Page Size = 65536
             let inner_mem_size = if opts.fixed_mem_size.is_some() {

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -273,6 +273,8 @@ pub mod syntax {
             MemStore(MemStore),
             MemSize,
             MemGrow,
+            MemCopy,
+            MemFill,
 
             // Control instructions
             Nop,


### PR DESCRIPTION
This adds support for `memory.copy` and `memory.fill` opcodes that are used by recent WASM toolchains, including clang.