### PR TITLE
parse more recent name sections

### DIFF
--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -81,7 +81,7 @@ pub mod syntax {
         pub struct TableIdx(pub u32);
         #[derive(Copy, Clone, Debug)]
         pub struct MemIdx(pub u32);
-        #[derive(Copy, Clone, Debug)]
+        #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
         pub struct GlobalIdx(pub u32);
         #[derive(Copy, Clone, Debug)]
         pub struct LocalIdx(pub u32);
@@ -315,7 +315,8 @@ pub mod syntax {
         pub struct Names {
             pub module: Option<Name>,
             pub functions: std::collections::HashMap<FuncIdx, Name>,
-            pub locals: std::collections::HashMap<FuncIdx, Vec<Name>>,
+            pub locals: std::collections::HashMap<LocalIdx, Vec<Name>>,
+            pub globals: std::collections::HashMap<GlobalIdx, Name>,
         }
 
         pub enum FuncInternals {


### PR DESCRIPTION
This adds support for parsing name sections emitted by recent wasm toolchains, such as clang.